### PR TITLE
Add --symlink option to execore-record-replay

### DIFF
--- a/scripts/execore-record.py
+++ b/scripts/execore-record.py
@@ -168,6 +168,7 @@ def dump_regs(fp, arch, epoch_insns):
     except gdb.error:
         return False
     fp.write(s)
+    fp.flush()
     return True
 
 


### PR DESCRIPTION
The use case is record-replaying a process running in a docker
container while using the host gdb. On the recording side, objfiles
contain host paths, but the core file contains container paths, which
are different for bind-mounted shared libraries. This confuses the
replaying side.

Don't try to resolve the relationships between the container and the
host path, just give the user a way to specify them manually.

While at it, drop shlex.join, which is not available on RHEL 8 (Python
3.6.8).

Closes #77.