### PR TITLE
Tolerate mappings larger than underlying files

### DIFF
--- a/src/execore_unistd.c
+++ b/src/execore_unistd.c
@@ -54,10 +54,9 @@ int EXECORE_(execvpe)(const char *file, char *const argv[],
   return -1;
 }
 
-ssize_t pread_exact(int fd, void *buf, size_t count, off_t offset) {
-  size_t orig_count = count;
-  while (count != 0) {
-    ssize_t n_read = pread(fd, buf, count, offset);
+int pread_exact(int fd, void **buf, size_t *count, off_t *offset) {
+  while (*count != 0) {
+    ssize_t n_read = pread(fd, *buf, *count, *offset);
     if (n_read < 0) {
       return -1;
     }
@@ -65,9 +64,9 @@ ssize_t pread_exact(int fd, void *buf, size_t count, off_t offset) {
       errno = EIO;
       return -1;
     }
-    buf += n_read;
-    count -= n_read;
-    offset += n_read;
+    *buf += n_read;
+    *count -= n_read;
+    *offset += n_read;
   }
-  return orig_count;
+  return 0;
 }

--- a/src/execore_unistd.h
+++ b/src/execore_unistd.h
@@ -29,11 +29,14 @@ static __attribute__((unused)) ssize_t pread(int fd, void *buf, size_t count,
 }
 #endif
 
-ssize_t pread_exact(int fd, void *buf, size_t count, off_t offset);
+int pread_exact(int fd, void **buf, size_t *count, off_t *offset);
 
 #define PREAD_EXACT(path, fd, buf, count, offset, label)                       \
   do {                                                                         \
-    if (pread_exact(fd, buf, count, offset) == -1) {                           \
+    void *__buf = (buf);                                                       \
+    size_t __count = (count);                                                  \
+    off_t __offset = (offset);                                                 \
+    if (pread_exact(fd, &__buf, &__count, &__offset) < 0) {                    \
       fprintf(stderr, "Could not read from %s: errno=%d\n", path, errno);      \
       goto label;                                                              \
     }                                                                          \


### PR DESCRIPTION
ld.so may produce from the following phdrs:

    Program Headers:
      Type           Offset             VirtAddr           PhysAddr
                     FileSiz            MemSiz              Flags  Align
      LOAD           0x0000000000000000 0x0000000000000000 0x0000000000000000
                     0x0000000000006054 0x0000000000006054  R E    0x10000
      LOAD           0x000000000000fb10 0x000000000001fb10 0x000000000001fb10
                     0x0000000000000504 0x00000000000005b0  RW     0x10000

the following mappings:

    3ff7d380000-3ff7d387000 r-xp 00000000 fd:00 8914604                      [...]
    3ff7d387000-3ff7d39f000 ---p 00007000 fd:00 8914604                      [...]
    3ff7d39f000-3ff7d3a0000 r--p 0000f000 fd:00 8914604                      [...]

where the 3ff7d387000-3ff7d39f000 mapping is padding larger than the underlying file. After execore recreates the mapping, trying to read the contents leads to EFAULT.